### PR TITLE
Use components and expose multiple package versions.

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "2020.06":
+    url: "https://github.com/mosra/corrade/archive/v2020.06.tar.gz"
+    sha256: "2a62492ccc717422b72f2596a3e1a6a105b9574aa9467917f12d19ef3aab1341"
+  "2019.10":
+    url: "https://github.com/mosra/corrade/archive/v2019.10.tar.gz"
+    sha256: "19dbf3c0b28a06a7017d627ee7b84c23b994c469198c1134a8aeba9cfbff7ec3"

--- a/conanfile.py
+++ b/conanfile.py
@@ -56,7 +56,7 @@ class CorradeConan(ConanFile):
     def source(self):
         # Rename to "source_subfolder" is a convention to simplify later steps
         tools.get(**self.conan_data["sources"][self.version])
-        os.rename(f"corrade-{self.version}", self._source_subfolder)
+        os.rename("corrade-{}".format(self.version), self._source_subfolder)
 
     def _configure_cmake(self):
         if not self._cmake:

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -3,11 +3,10 @@ project(test_package)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(Corrade REQUIRED Containers Utility)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} Corrade::Containers Corrade::Utility)
 
 set_target_properties(${PROJECT_NAME} 
     PROPERTIES 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -8,7 +8,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)
@@ -16,5 +16,4 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        self.run("./test_package", run_environment=True)

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -1,8 +1,10 @@
 #include <cstdlib>
 #include <Corrade/Utility/Debug.h>
+#include <Corrade/Containers/Array.h>
 
 int main() {
-    Corrade::Utility::Debug() << "Success";
+    Corrade::Utility::Debug{} << Corrade::Containers::Array<int>{5};
+    Corrade::Utility::Debug{} << "Success";
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hey as noted [here](https://github.com/mosra/corrade/issues/91#issuecomment-673999166), I think it
would be great to have a more seamless cmake integration. I've added the appropriate components, though there might need to be some more thought for how to enable/disable individual components. The 'Containers'
and the 'Utility' component depend cyclically on each other, and there are a couple of components depending of the 'Containers' component. At the moment everything works fine for me on linux, but one could think about modeling those realations more closely (e.g. enabling the Utility component when someone enable the Interconnect component).